### PR TITLE
Handling layer init errors (including certificate)

### DIFF
--- a/source/SquadLeader/src/com/esri/squadleader/controller/MapController.java
+++ b/source/SquadLeader/src/com/esri/squadleader/controller/MapController.java
@@ -112,6 +112,7 @@ public class MapController extends com.esri.militaryapps.controller.MapControlle
 
     private final MapView mapView;
     private final AssetManager assetManager;
+    private final OnStatusChangedListener layerListener;
     private final List<BasemapLayer> basemapLayers = new ArrayList<BasemapLayer>();
     private final List<Layer> nonBasemapLayers = new ArrayList<Layer>();
     private final GraphicsLayer locationGraphicsLayer = new GraphicsLayer();
@@ -125,9 +126,14 @@ public class MapController extends com.esri.militaryapps.controller.MapControlle
     /**
      * Creates a new MapController.
      * @param mapView the MapView being controlled by the new MapController.
+     * @param assetManager the application's AssetManager.
+     * @param layerListener an OnStatusChangedListener that will be set for each layer that is added to
+     *                      the map through this MapController. If null, each layer will keep its existing
+     *                      or default listener.
      */
     @SuppressWarnings("serial")
-    public MapController(final MapView mapView, AssetManager assetManager) {
+    public MapController(final MapView mapView, AssetManager assetManager, OnStatusChangedListener layerListener) {
+        this.layerListener = layerListener;
         ((LocationController) getLocationController()).setLocationService(mapView.getLocationService());
         this.mapView = mapView;
         mapView.setOnStatusChangedListener(new OnStatusChangedListener() {
@@ -373,6 +379,9 @@ public class MapController extends com.esri.militaryapps.controller.MapControlle
      */
     private void addLayer(Layer layer, boolean isOverlay) {
         //TODO do something with isOverlay (i.e. implement overlay layers)
+        if (null != layerListener) {
+            layer.setOnStatusChangedListener(layerListener);
+        }
         mapView.addLayer(layer);
         nonBasemapLayers.add(layer);
         fireLayersChanged(isOverlay);
@@ -395,6 +404,9 @@ public class MapController extends com.esri.militaryapps.controller.MapControlle
      */
     private void addBasemapLayer(BasemapLayer basemapLayer, boolean isOverlay) {
         //TODO do something with isOverlay (i.e. implement overlay layers)
+        if (null != layerListener) {
+            basemapLayer.getLayer().setOnStatusChangedListener(layerListener);
+        }
         mapView.addLayer(basemapLayer.getLayer(), basemapLayers.size());
         basemapLayers.add(basemapLayer);
         if (basemapLayer.getLayer().isVisible()) {

--- a/source/SquadLeader/src/com/esri/squadleader/view/AddLayerFromWebDialogFragment.java
+++ b/source/SquadLeader/src/com/esri/squadleader/view/AddLayerFromWebDialogFragment.java
@@ -95,34 +95,6 @@ public class AddLayerFromWebDialogFragment extends DialogFragment {
                                 Throwable cause = e;
                                 while (null != cause && !foundCpve) {
                                     if (cause instanceof CertPathValidatorException) {
-                                        StringBuilder sb = new StringBuilder("The server presented a certificate that is invalid, is untrusted, or belongs ")
-                                                .append("to a server with a different hostname. This app has no way of knowing whether that server is operated ")
-                                                .append("by a trustworthy party. You can connect anyway at your own risk by accepting the certificate.\n\nDetails:");
-                                        CertPathValidatorException cpve = (CertPathValidatorException) cause;
-                                        CertPath certPath = cpve.getCertPath();
-                                        Certificate cert = certPath.getCertificates().get(0);
-                                        if (cert instanceof X509Certificate) {
-                                            X509Certificate x509Cert = (X509Certificate) cert;
-                                            sb.append("\nIssued to: '").append(x509Cert.getSubjectDN().getName()).append("'");
-                                            sb.append("\nIssued by: '").append(x509Cert.getIssuerDN().getName()).append("'");
-                                            sb.append("\nValid from " ).append(x509Cert.getNotBefore().toString()).append(" to ").append(x509Cert.getNotAfter().toString());
-                                        } else {
-                                            sb.append(cert.toString());
-                                        }
-                                        sb.append("\n\nNOTE: tapping the Accept button doesn't actually work yet. This will work in a future Squad Leader build.");
-                                        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-                                        builder.setMessage(sb.toString())
-                                               .setTitle(R.string.cert_error_dialog_title);
-                                        builder.setPositiveButton(R.string.accept, new DialogInterface.OnClickListener() {
-                                            public void onClick(DialogInterface dialog, int id) {
-                                                //TODO figure out how to accept the certificate before calling addLayer again
-                                                addLayer(useAsBasemap, urlString);
-                                            }
-                                        });
-                                        builder.setNegativeButton(R.string.refuse_recommended, null);
-
-                                        AlertDialog dialog = builder.create();
-                                        dialog.show();
                                         foundCpve = true;
                                     } else {
                                         cause = cause.getCause();
@@ -130,7 +102,9 @@ public class AddLayerFromWebDialogFragment extends DialogFragment {
                                 }
                                 if (!foundCpve) {
                                     Toast.makeText(activity, "Couldn't add layer from web: " + e.getClass().getName() + ": " + e.getMessage(), Toast.LENGTH_LONG).show();
-                                }                                                
+                                } else {
+                                    Toast.makeText(activity, "Couldn't add layer: Untrusted certificate for " + urlString, Toast.LENGTH_LONG).show();
+                                }
                             }
                         });
                         return null;

--- a/source/SquadLeader/src/com/esri/squadleader/view/LayerErrorListener.java
+++ b/source/SquadLeader/src/com/esri/squadleader/view/LayerErrorListener.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright 2013 Esri
+ * 
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ ******************************************************************************/
+package com.esri.squadleader.view;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import com.esri.android.map.Layer;
+import com.esri.android.map.event.OnStatusChangedListener;
+
+/**
+ * A listener that listens for layer initialization errors and provides UI feedback.
+ */
+public class LayerErrorListener implements OnStatusChangedListener {
+
+    private static final long serialVersionUID = 2780740452655213139L;
+    
+    private final Context context;
+    
+    /**
+     * Creates a new LayerErrorListener
+     * @param context the Context used for displaying a Toast when layer initialization fails.
+     */
+    public LayerErrorListener(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void onStatusChanged(Object source, STATUS status) {
+        if (STATUS.INITIALIZATION_FAILED.equals(status)) {
+            if (source instanceof Layer) {
+                Layer layer = (Layer) source;
+                Toast.makeText(context, "Error loading layer " + layer.getUrl() + ": " + status.getError().getDescription(), Toast.LENGTH_LONG).show();
+            }
+        }
+    }    
+
+}

--- a/source/SquadLeader/src/com/esri/squadleader/view/SquadLeaderActivity.java
+++ b/source/SquadLeader/src/com/esri/squadleader/view/SquadLeaderActivity.java
@@ -337,7 +337,7 @@ public class SquadLeaderActivity extends FragmentActivity
             
         });
 
-        mapController = new MapController(mapView, getAssets());
+        mapController = new MapController(mapView, getAssets(), new LayerErrorListener(this));
         ((NorthArrowView) findViewById(R.id.northArrowView)).setMapController(mapController);
         try {
             mil2525cController = new AdvancedSymbolController(


### PR DESCRIPTION
Displaying a Toast, without letting the user accept an untrusted
certificate

Fixes #9
