### PR TITLE
Catching all Throwable objects when creating ViewshedController

### DIFF
--- a/source/SquadLeader/app/src/main/java/com/esri/squadleader/view/SquadLeaderActivity.java
+++ b/source/SquadLeader/app/src/main/java/com/esri/squadleader/view/SquadLeaderActivity.java
@@ -513,8 +513,8 @@ public class SquadLeaderActivity extends Activity
             viewshedController = new ViewshedController(elevationPath);
             mapController.addLayer(viewshedController.getLayer());
             findViewById(R.id.toggleButton_viewshed).setVisibility(View.VISIBLE);
-        } catch (Exception e) {
-            Log.d(TAG, "Couldn't set up ViewshedController", e);
+        } catch (Throwable t) {
+            Log.d(TAG, "Couldn't set up ViewshedController", t);
             findViewById(R.id.toggleButton_viewshed).setVisibility(View.INVISIBLE);
         }
     }


### PR DESCRIPTION
This way, if the device doesn't support RenderScript (e.g. an emulator),
the app does not crash.