### PR TITLE
Version bump

### DIFF
--- a/source/SquadLeader/app/src/main/AndroidManifest.xml
+++ b/source/SquadLeader/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.esri.squadleader"
     android:installLocation="internalOnly"
     android:versionCode="8"
-    android:versionName="5.1.0" >
+    android:versionName="6.0.0" >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />


### PR DESCRIPTION
Some changes we have made in the next version are backward-incompatible
from an API perspective. Therefore, it's going to be v6.0.0 instead of
v5.1.0.